### PR TITLE
Adding support for Visual Studio Live Share

### DIFF
--- a/src/exclusionHelper.ts
+++ b/src/exclusionHelper.ts
@@ -3,7 +3,7 @@ import * as minimatch from 'minimatch';
 
 const separator = '/';
 
-const allowedSchemes = new Set(['file', 'untitled']);
+const allowedSchemes = new Set(['file', 'untitled', 'vsls']);
 
 export type ExclusionFunction = (filename: string) => boolean;
 


### PR DESCRIPTION
This PR adds support for [Visual Studio Live Share](http://aka.ms/vsls), by allowing spell checking to work against `vsls:` files, which is the scheme for documents on the "guest side" of a Live Share collaboration session. This ensures that developers who rely on the Code Spell Checker extension, to continue benefiting from it when pairing with another developer.

An equivalent change will need to be made in the [VS Code extension](https://github.com/Jason-Rev/vscode-spell-checker), which I will send out separately.

// CC @Jason3S