### PR TITLE
[Live Share] Remove VSLS from supported scheme list

### DIFF
--- a/src/exclusionHelper.ts
+++ b/src/exclusionHelper.ts
@@ -3,7 +3,7 @@ import * as minimatch from 'minimatch';
 
 const separator = '/';
 
-const defaultAllowedSchemes = new Set(['file', 'untitled', 'vsls']);
+const defaultAllowedSchemes = new Set(['file', 'untitled']);
 
 export type ExclusionFunction = (filename: string) => boolean;
 


### PR DESCRIPTION
Since making PR #28, we've added support to Visual Studio Live Share which allows language services to be remoted from the host (i.e. the developer that shared) to all of their guests. In order to optimize for the scenario where the host and guest both have the Code Spell Checker extension installed, we only want the host's to be generating diagnostics, since it would have full access to the project. Therefore, this PR undoes #28, in order to provide a better Live Share experience. Apologies for the churn!