### PR TITLE
using path.resolve() for dictionary paths

### DIFF
--- a/src/Settings/DictionarySettings.ts
+++ b/src/Settings/DictionarySettings.ts
@@ -33,7 +33,7 @@ function getFullPathName(def: DictionaryDefinition) {
         return '';
     }
     const dictPath = path.join(filePath || dictionaryPath(), file);
-    return dictPath;
+    return path.resolve(dictPath);
 }
 
 export function normalizePathForDictDefs(defs: DictionaryDefinition[], defaultPath: string): DictionaryDefinition[] {


### PR DESCRIPTION
Import settings and others are using `path.resolve()`.
I am pleased that you will also allow dictionary paths.