### PR TITLE
Fix bin problem on npm install

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('./dist/app');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "bin": {
-    "cspell": "./dist/app.js"
+    "cspell": "bin.js"
   },
   "files": [
     "dist/**",


### PR DESCRIPTION
Fixes a problem with non-existent `bin` file when the project is cloned and installed. See https://github.com/Jason3S/cspell/issues/53#issuecomment-404451827