### PR TITLE
Added Ghent University

### DIFF
--- a/migrated_dictionaries/companies.txt
+++ b/migrated_dictionaries/companies.txt
@@ -367,6 +367,7 @@ Genuine Parts Company
 Genworth Financial, Inc.
 George Weston
 GeoTrust Global
+Ghent University
 Gilead Sciences, Inc.
 GlaxoSmithKline
 Glencore International
@@ -907,6 +908,7 @@ U.S. Bancorp
 U.S. Postal Service
 Uber
 UBS
+UGent
 UGI Corporation
 Ultrapar Holdings
 UniCredit Group
@@ -924,6 +926,7 @@ United Technologies
 United Technologies
 UnitedHealth Group
 Universal Health Services, Inc.
+Universiteit Gent
 Unum Group
 URS Corporation
 US Foods, Inc.


### PR DESCRIPTION
These are the three official ways to write the name of Ghent University (https://www.ugent.be/)