### PR TITLE
Add PowerShell ExecutionPolicy words

### DIFF
--- a/dictionaries/powershell.txt
+++ b/dictionaries/powershell.txt
@@ -57,7 +57,6 @@ control
 correctly
 d
 DebugPreference
-default
 define
 definition
 DESCRIPTION
@@ -144,7 +143,6 @@ lg
 like
 line
 LINK
-local
 logical
 lt
 make
@@ -192,10 +190,8 @@ pattern
 patterns
 PID
 plist
-PowerShell
 preference
 private
-process
 Profile
 ProgressPreference
 PropertyList
@@ -240,7 +236,6 @@ return
 s
 schema
 scientific
-scope
 scopeName
 script
 scriptblock
@@ -310,6 +305,18 @@ www
 xml
 xor
 z
+[Microsoft.PowerShell.ExecutionPolicy]::AllSigned
+[Microsoft.PowerShell.ExecutionPolicy]::Bypass
+[Microsoft.PowerShell.ExecutionPolicy]::Default
+[Microsoft.PowerShell.ExecutionPolicy]::RemoteSigned
+[Microsoft.PowerShell.ExecutionPolicy]::Restricted
+[Microsoft.PowerShell.ExecutionPolicy]::Undefined
+[Microsoft.PowerShell.ExecutionPolicy]::Unrestricted
+[Microsoft.PowerShell.ExecutionPolicyScope]::CurrentUser
+[Microsoft.PowerShell.ExecutionPolicyScope]::LocalMachine
+[Microsoft.PowerShell.ExecutionPolicyScope]::MachinePolicy
+[Microsoft.PowerShell.ExecutionPolicyScope]::Process
+[Microsoft.PowerShell.ExecutionPolicyScope]::UserPolicy
 [System.Management.Automation.VerbsCommon]::Add
 [System.Management.Automation.VerbsCommon]::Clear
 [System.Management.Automation.VerbsCommon]::Close


### PR DESCRIPTION
They are built-in enum words. For more information, see the following links:
* [About Execution Policies](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-6)
* [ExecutionPolicy Enum](https://docs.microsoft.com/en-us/dotnet/api/microsoft.powershell.executionpolicy?view=powershellsdk-1.1.0)
* [ExecutionPolicyScope Enum](https://docs.microsoft.com/en-us/dotnet/api/microsoft.powershell.executionpolicyscope?view=powershellsdk-1.1.0)